### PR TITLE
Add talks

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -33,8 +33,20 @@ const worksCollection = defineCollection({
     }),
 });
 
+const talksCollection = defineCollection({
+  loader: glob({ pattern: "**/[^_]*.json", base: "./src/content/talks" }),
+  schema: z.array(
+    z.object({
+      id: z.string(),
+      url: z.string().url().optional(),
+      date: z.coerce.date(),
+    }),
+  ),
+});
+
 export const collections = {
   "about-me": aboutMeCollection,
   "about-portfolio": aboutPortfolioCollection,
   works: worksCollection,
+  talks: talksCollection,
 };

--- a/src/content/talks/2023.json
+++ b/src/content/talks/2023.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "次世代Webカンファレンス2023",
+    "url": "https://nextwebconf.connpass.com/event/300174/",
+    "date": "2023-12-16"
+  },
+  {
+    "id": "WCAN 2023 Winter & 忘年会",
+    "url": "https://wcan.jp/event/wcan2023-winter.html",
+    "date": "2023-12-02"
+  },
+  {
+    "id": "つくって終わらないブランドの裏側 ー エイチームのブランドデザイン ー",
+    "url": "https://cocoda-ateam-brand.peatix.com/?lang=ja",
+    "date": "2023-11-21"
+  },
+  {
+    "id": "実装の観点からみたUXデザインに対するデザイナーとエンジニアの心構え【キニナルDevOps講座 vol.8】",
+    "url": "https://licensecounter.jp/devops-hub/info/event/uxpin-devops-vol8/",
+    "date": "2023-11-20"
+  },
+  {
+    "id": "#朝までマークアップ",
+    "url": "https://cssnite.doorkeeper.jp/events/163736",
+    "date": "2023-11-02"
+  },
+  {
+    "id": "名古屋学芸大学 卒業生によるトークイベント",
+    "date": "2023-11-02"
+  },
+  {
+    "id": "みんなでわいわい！デザイナーやデザインに興味のある方の懇親会 @名古屋",
+    "url": "https://friends.figma.com/events/details/figma-nagoya-presents-minnadewaiwaidezainayadezainnixing-wei-noarufang-noken-qin-hui-ming-gu-wu/",
+    "date": "2023-10-27"
+  },
+  {
+    "id": "名古屋学芸大学 講義",
+    "date": "2023-09-25"
+  },
+  {
+    "id": "なごデLT",
+    "date": "2023-08-20"
+  },
+  {
+    "id": "「Figmaデザイン入門」著者が教える！はじめてのFigmaワークショップ @名古屋",
+    "url": "https://friends.figma.com/events/details/figma-nagoya-presents-figmadezainru-men-zhu-zhe-gajiao-eruhazimetenofigmawakushiyotsupu-ming-gu-wu/",
+    "date": "2023-07-27"
+  },
+  {
+    "id": "WCAN mini 2023 Vol.1",
+    "url": "https://wcan.jp/event/wcan_mini2023_1.html",
+    "date": "2023-07-08"
+  },
+  {
+    "id": "ReDesigner Online Meetup",
+    "url": "https://redesignerforstudent.connpass.com/event/284193/",
+    "date": "2023-06-17"
+  },
+  {
+    "id": "CSS Nite チーム全員でUIデザイン 今日からはじめるFigma入門 2",
+    "url": "https://cssnite.doorkeeper.jp/events/155881",
+    "date": "2023-06-17"
+  },
+  {
+    "id": "Config2023 Recap in Goodpatch",
+    "url": "https://goodpatch.connpass.com/event/287493/",
+    "date": "2023-06-06"
+  },
+  {
+    "id": "ポートフォリオ展とインターン展 2023",
+    "url": "https://www.vivivit.com/events/portfolio-ten-and-intern-ten",
+    "date": "2023-06-03"
+  },
+  {
+    "id": "Figma勉強会 @スタメンオフィス",
+    "date": "2023-05-28"
+  },
+  {
+    "id": "デザナレ展 | 謎に包まれた仕様書やFigmaを一挙にさわれる展示！リアルで見知れるデザインプロセス",
+    "url": "https://vivivit.connpass.com/event/276931/",
+    "date": "2023-03-24"
+  },
+  {
+    "id": "CSS Nite チーム全員でUIデザイン 今日からはじめるFigma入門",
+    "url": "https://cssnite.doorkeeper.jp/events/151010",
+    "date": "2023-02-09"
+  }
+]

--- a/src/content/talks/2024.json
+++ b/src/content/talks/2024.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "Stack Nagoya Fes Vol.3",
+    "url": "https://stacknagoya.connpass.com/event/334211/",
+    "date": "2024-12-14"
+  },
+  {
+    "id": "株式会社スタメン 社内勉強会 ゲスト参加",
+    "url": "https://x.com/stmn_designer/status/1861716551491310063",
+    "date": "2024-11-26"
+  },
+  {
+    "id": "ITトリオの日常 ラジオ出演 後編",
+    "url": "https://it-trio-no.com/episode/123",
+    "date": "2024-11-18"
+  },
+  {
+    "id": "トライデントコンピュータ専門学校 講義",
+    "date": "2024-11-13"
+  },
+  {
+    "id": "ITトリオの日常 ラジオ出演 前編",
+    "url": "https://it-trio-no.com/episode/122",
+    "date": "2024-11-11"
+  },
+  {
+    "id": "朝までFigma",
+    "url": "https://cssnite.doorkeeper.jp/events/177499",
+    "date": "2024-10-25"
+  },
+  {
+    "id": "名古屋学芸大学 講義",
+    "date": "2024-09-23"
+  },
+  {
+    "id": "デザイナーとエンジニアのためのFigma活用セミナー",
+    "url": "https://salesroadshownagoya.splashthat.com/",
+    "date": "2024-08-29"
+  },
+  {
+    "id": "Stack Nagoya Fes Vol.2「リーダーの裏側〜行動力から得た経験と失敗談〜」",
+    "url": "https://stacknagoya.connpass.com/event/315511/",
+    "date": "2024-07-20"
+  },
+  {
+    "id": "Qiita Engineer Festa 2024 前夜祭 ～夏の記事投稿大祭典！～",
+    "url": "https://increments.connpass.com/event/317335/",
+    "date": "2024-06-03"
+  },
+  {
+    "id": "SaCSS Season2 Special03 : 個々の成長戦略〜技術の学びや仕事への繋げ方〜（SaCSS Season2 vol.8）",
+    "url": "https://sacss-s2-special03.peatix.com/",
+    "date": "2024-04-13"
+  },
+  {
+    "id": "エイチーム 学生向けポートフォリオ添削イベント",
+    "date": "2024-03-11"
+  }
+]

--- a/src/content/talks/2025.json
+++ b/src/content/talks/2025.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "Friends of Figma Osaka #07 w/ FoF Nagoya",
+    "url": "https://friends.figma.com/events/details/figma-osaka-presents-friends-of-figma-osaka-07-w-fof-nagoya/",
+    "date": "2025-04-11"
+  },
+  {
+    "id": "専門学校・大学合同Web制作合宿 講評",
+    "date": "2025-03-28"
+  },
+  {
+    "id": "朝までマークアップ 2（CSS編）",
+    "url": "https://cssnite.doorkeeper.jp/events/179874",
+    "date": "2025-01-31"
+  }
+]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import darkTheme from "../assets/20231006-dark_theme.jpg";
 import kininaruDevops from "../assets/20231120-kininaru_devops.jpg";
 
 const allWorks = await getCollection("works");
+const allTalks = await getCollection("talks");
 ---
 
 <GlobalLayout>
@@ -132,6 +133,46 @@ const allWorks = await getCollection("works");
             </a>
           ))
       }
+    </section>
+    <section class="col-start-3 col-end-4 flex flex-col gap-y-4" id="talks">
+      <h2 class="text-3xl font-bold">登壇</h2>
+      <table class="border-t border-gray-300">
+        <thead>
+          <tr
+            class="border-b border-gray-300 text-left [&>th]:px-1.5 [&>th]:py-1"
+          >
+            <th class="w-20">日時</th>
+            <th>タイトル</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            allTalks
+              .flatMap((talk) => talk.data)
+              .sort(
+                (a, b) =>
+                  new Date(b.date).getTime() - new Date(a.date).getTime(),
+              )
+              .slice(0, 5)
+              .map((talk) => (
+                <tr class="border-b border-gray-300 align-top [&>td]:px-1.5 [&>td]:py-1">
+                  <td class="proportional-nums">
+                    {new Date(talk.date).toLocaleDateString("ja-JP", {
+                      dateStyle: "medium",
+                    })}
+                  </td>
+                  <td>{talk.id}</td>
+                </tr>
+              ))
+          }
+        </tbody>
+      </table>
+      <a
+        href="/talks"
+        class="self-start text-cyan-600 underline hover:text-cyan-900"
+      >
+        直近のすべての登壇
+      </a>
     </section>
     <section
       id="blog"

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -1,0 +1,60 @@
+---
+import { getCollection } from "astro:content";
+import Footer from "../../components/Footer.astro";
+import GlobalLayout from "../../layouts/GlobalLayout.astro";
+
+const allTalks = await getCollection("talks");
+---
+
+<GlobalLayout>
+  <div class="flex flex-col gap-16 px-3 pt-10 sm:px-5 md:px-7 md:pt-16">
+    <article
+      class="flex w-full max-w-[var(--container-3xl)] flex-col gap-y-6 self-center sm:gap-y-8"
+    >
+      <h1 class="text-3xl font-bold sm:text-5xl md:text-7xl">登壇実績</h1>
+      {
+        allTalks
+          .sort((a, b) => new Date(b.id).getTime() - new Date(a.id).getTime())
+          .map((talk) => (
+            <section class="flex flex-col gap-y-2 sm:gap-y-3">
+              <h2 class="text-xl font-bold sm:text-3xl md:text-4xl">
+                {`${talk.id}年`}
+              </h2>
+              <table class="border-t border-gray-300">
+                <thead>
+                  <tr class="border-b border-gray-300 text-left [&>th]:px-1.5 [&>th]:py-1">
+                    <th class="w-20">日時</th>
+                    <th>タイトル</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {talk.data.map((talk) => (
+                    <tr class="border-b border-gray-300 align-top [&>td]:px-1.5 [&>td]:py-1">
+                      <td class="proportional-nums">
+                        {talk.date.toLocaleDateString("ja-JP", {
+                          dateStyle: "medium",
+                        })}
+                      </td>
+                      <td>
+                        {talk.url ? (
+                          <a
+                            class="text-cyan-600 underline hover:text-cyan-900"
+                            href={talk.url}
+                          >
+                            {talk.id}
+                          </a>
+                        ) : (
+                          talk.id
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          ))
+      }
+    </article>
+    <Footer />
+  </div>
+</GlobalLayout>


### PR DESCRIPTION
# Implemented

- Add `talks` content collection
- Create new talks page (`/talks`)
- Display the latest 5 talks on the top page

# Screenshots

|  | Before | After |
| - | - | - |
| top | ![top-before](https://github.com/user-attachments/assets/2ceccc41-b915-4fed-b5aa-7cae38c89666) | ![top-after](https://github.com/user-attachments/assets/ebb5f477-0c32-423e-8686-4eaa5f320f3d) |
| /talks | none | ![talks-after](https://github.com/user-attachments/assets/6b635ba7-4879-4799-83c0-cd50f8221f15) |

<!--
OR 

> [!NOTE]
> No screenshots attached as there is no change in appearance
-->