### PR TITLE
feat: Qiita APIから記事を取得し表示する機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ This is an Astro-based portfolio website for Keisuke Watanuki with Japanese cont
   - `works` - Portfolio projects with cover images, dates, and keywords
   - `talks` - Speaking engagements stored as JSON files by year
   - `about-me` and `about-portfolio` - Static content pages
+  - `qiita-articles` - Dynamic articles fetched from Qiita API using custom loader
 - **Content Structure**: All content files are in `src/content/` with markdown for rich content and JSON for structured data
+- **External API Integration**: Qiita API integration using custom loaders for dynamic content fetching at build time
 
 ### Styling & UI
 
@@ -50,6 +52,7 @@ This is an Astro-based portfolio website for Keisuke Watanuki with Japanese cont
 - **3D Background**: `granyGradients.ts` creates animated gradient effects using Three.js with custom shaders
 - **Intersection Observer**: Used for scroll-based UI animations (scroll guide visibility)
 - **Image Optimization**: Uses Astro's built-in Image component with Sharp
+- **Custom Content Loaders**: Qiita API integration with error handling, timeout controls, and graceful fallbacks for external content fetching
 
 ### File Organization
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { z, defineCollection } from "astro:content";
+import type { Loader } from "astro/loaders";
 import { glob } from "astro/loaders";
+import { defineCollection, z } from "astro:content";
 
 const aboutMeCollection = defineCollection({
   loader: glob({ pattern: "**/[^_]*.md", base: "./src/content/about-me" }),
@@ -44,9 +45,103 @@ const talksCollection = defineCollection({
   ),
 });
 
+// Qiita記事取得用定数
+const QIITA_API_LIMIT = 5;
+const QIITA_API_TIMEOUT = 10000;
+const QIITA_USERNAME = "kskwtnk";
+
+// Qiita APIからデータを取得するヘルパー関数
+async function fetchQiitaArticles(
+  username: string,
+  perPage: number = QIITA_API_LIMIT,
+) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), QIITA_API_TIMEOUT);
+
+  try {
+    const response = await fetch(
+      `https://qiita.com/api/v2/users/${username}/items?page=1&per_page=${perPage}`,
+      {
+        signal: controller.signal,
+        headers: { "User-Agent": "Portfolio-Site/1.0" },
+      },
+    );
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(
+        `Qiita API returned ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    return await response.json();
+  } catch (error: unknown) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Qiita API request timed out");
+    }
+    throw error;
+  }
+}
+
+// Qiita記事カスタムローダー
+function qiitaArticlesLoader(username: string = QIITA_USERNAME): Loader {
+  return {
+    name: "qiita-loader",
+    load: async ({ store, logger, parseData }) => {
+      let articles = [];
+
+      try {
+        articles = await fetchQiitaArticles(username);
+        logger.info(`Successfully fetched ${articles.length} Qiita articles`);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          logger.error(`Qiita API fetch failed: ${error.message}`);
+          // エラー時は空配列を返し、UIで「記事の取得に失敗しました。」を表示する
+          articles = [];
+        }
+      }
+
+      for (const article of articles) {
+        try {
+          const id = article.id;
+          const articleData = {
+            title: article.title || "Untitled",
+            url: article.url || "",
+            created_at: article.created_at || new Date().toISOString(),
+          };
+
+          const data = await parseData({ id, data: articleData });
+
+          store.set({ id, data });
+        } catch (parseError: unknown) {
+          if (parseError instanceof Error) {
+            logger.warn(
+              `Failed to parse article ${article.id}: ${parseError.message}`,
+            );
+          }
+        }
+      }
+
+      logger.info(`Successfully loaded ${articles.length} Qiita articles`);
+    },
+  };
+}
+
+const qiitaArticlesCollection = defineCollection({
+  loader: qiitaArticlesLoader(QIITA_USERNAME),
+  schema: z.object({
+    title: z.string(),
+    url: z.string().url(),
+    created_at: z.string(),
+  }),
+});
+
 export const collections = {
   "about-me": aboutMeCollection,
   "about-portfolio": aboutPortfolioCollection,
   works: worksCollection,
   talks: talksCollection,
+  "qiita-articles": qiitaArticlesCollection,
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,10 @@ import { getCollection } from "astro:content";
 import GlobalLayout from "../layouts/GlobalLayout.astro";
 import Footer from "../components/Footer.astro";
 import GrainyGradients from "../components/GrainyGradients.astro";
-import darkTheme from "../assets/20231006-dark_theme.jpg";
-import kininaruDevops from "../assets/20231120-kininaru_devops.jpg";
 
 const allWorks = await getCollection("works");
 const allTalks = await getCollection("talks");
+const qiitaArticles = await getCollection("qiita-articles");
 ---
 
 <GlobalLayout>
@@ -174,26 +173,59 @@ const allTalks = await getCollection("talks");
         直近のすべての登壇
       </a>
     </section>
-    <section
-      id="blog"
-      class="col-start-3 col-end-4 grid grid-cols-4 flex-col gap-4"
-    >
-      <h2 class="col-span-full text-3xl font-bold">記事</h2>
+    <section class="col-start-3 col-end-4 flex flex-col gap-y-4" id="blog">
+      <h2 class="text-3xl font-bold">記事</h2>
+      <table class="border-t border-gray-300">
+        <thead>
+          <tr
+            class="border-b border-gray-300 text-left [&>th]:px-1.5 [&>th]:py-1"
+          >
+            <th class="w-20">日時</th>
+            <th>タイトル</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            qiitaArticles.length > 0 ? (
+              // Qiita APIから返ってくるのが記事の作成日時の降順なのでsortは不要
+              // https://qiita.com/api/v2/docs#get-apiv2usersuser_iditems
+              qiitaArticles.map((article) => (
+                <tr class="border-b border-gray-300 align-top [&>td]:px-1.5 [&>td]:py-1">
+                  <td class="proportional-nums">
+                    {new Date(article.data.created_at).toLocaleDateString(
+                      "ja-JP",
+                      {
+                        dateStyle: "medium",
+                      },
+                    )}
+                  </td>
+                  <td>
+                    <a
+                      href={article.data.url}
+                      target="_blank"
+                      class="text-cyan-600 underline hover:text-cyan-900"
+                    >
+                      {article.data.title}
+                    </a>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr class="border-b border-gray-300 align-top [&>td]:px-1.5 [&>td]:py-1">
+                <td colspan="2" class="px-1.5 py-1 text-center text-gray-500">
+                  記事の取得に失敗しました。
+                </td>
+              </tr>
+            )
+          }
+        </tbody>
+      </table>
       <a
-        href="https://qiita.com/kskwtnk/items/9fac826a2e1c8526aa50"
-        class="col-span-full grid gap-1 md:col-span-2"
+        href="https://qiita.com/kskwtnk"
         target="_blank"
+        class="self-start text-cyan-600 underline hover:text-cyan-900"
       >
-        <Image src={darkTheme} alt="" class="rounded-md" />
-        <h3 class="text-md">12 年続くサービスにダークテーマ UI を導入した</h3>
-      </a>
-      <a
-        href="https://qiita.com/kskwtnk/items/1c9e626f28a2798fdc21"
-        class="col-span-full grid gap-1 md:col-span-2"
-        target="_blank"
-      >
-        <Image src={kininaruDevops} alt="" class="rounded-md" />
-        <h3 class="text-md">デザインデータとコードを一体のものとして捉える</h3>
+        すべての記事
       </a>
     </section>
     <div class="col-start-2 col-end-5">


### PR DESCRIPTION
Fixes #313

ポートフォリオサイトの記事セクションを手動から動的取得に変更しました。

**変更内容:**
- Qiita API v2で最新5件の記事を動的取得
- 「登壇」セクションと同じテーブル形式で表示
- 記事タイトルにリンク機能を追加
- API取得失敗時のフォールバック機能を実装
- 「すべての記事」リンクをhttps://qiita.com/kskwtnkに設定

Generated with [Claude Code](https://claude.ai/code)