### PR TITLE
Add .mcp.json to use Astro docs, context7 and playwright

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "Astro docs": {
+      "type": "http",
+      "url": "https://mcp.docs.astro.build/mcp"
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
# Implemented

- Add .mcp.json to use Astro docs, context7 and playwright

# Screenshots

> [!NOTE]
> No screenshots attached as there is no change in appearance
