### PR TITLE
feat: 登壇履歴をアップデートする

### DIFF
--- a/src/content/talks/2022.json
+++ b/src/content/talks/2022.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "Designship 2022 Extra Stage",
+    "url": "https://design-ship.jp/2022/extra-stage",
+    "date": "2022-12-04"
+  },
+  {
+    "id": "CSS Nite Coder's High 2022 (Part 3)",
+    "url": "https://cssnite.doorkeeper.jp/events/141697",
+    "date": "2022-11-25"
+  },
+  {
+    "id": "Figma Japan Community Event",
+    "url": "https://qiita.com/xrxoxcxox/items/29629bbbca926cca9934",
+    "date": "2022-07-27"
+  },
+  {
+    "id": "デザイン・フロントエンドのモデリング事情",
+    "url": "https://qiita.com/xrxoxcxox/items/425a6223126da5403682",
+    "date": "2022-07-06"
+  },
+  {
+    "id": "CSS Nite Figmaの制作フロー大解剖〜UI制作からコーディングまで",
+    "url": "https://cssnite.doorkeeper.jp/events/135648",
+    "date": "2022-05-21"
+  },
+  {
+    "id": "Tokyo Config Watch Party",
+    "url": "https://qiita.com/xrxoxcxox/items/261b4b63bfd3fe688b17",
+    "date": "2022-05-11"
+  },
+  {
+    "id": "ゆるデザトーク",
+    "date": "2022-02-20"
+  }
+]

--- a/src/content/talks/2025.json
+++ b/src/content/talks/2025.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "Figma Config 2025はどうだった？現地参加者たちを招いたRecapイベント",
+    "url": "https://cybozu.connpass.com/event/358821/",
+    "date": "2025-06-23"
+  },
+  {
     "id": "Friends of Figma Osaka #07 w/ FoF Nagoya",
     "url": "https://friends.figma.com/events/details/figma-osaka-presents-friends-of-figma-osaka-07-w-fof-nagoya/",
     "date": "2025-04-11"

--- a/src/layouts/GlobalLayout.astro
+++ b/src/layouts/GlobalLayout.astro
@@ -3,8 +3,8 @@ import "@fontsource/shippori-mincho/400.css";
 import "@fontsource/shippori-mincho/700.css";
 import { ClientRouter } from "astro:transitions";
 import "../styles/global.css";
-const { title = "綿貫佳祐", excerpt = "綿貫佳祐のポートフォリオ" } =
-  Astro.props;
+const { title, excerpt = "綿貫佳祐のポートフォリオ" } = Astro.props;
+const pageTitle = title ? `${title} | 綿貫佳祐` : "綿貫佳祐";
 ---
 
 <html lang="ja">
@@ -13,7 +13,7 @@ const { title = "綿貫佳祐", excerpt = "綿貫佳祐のポートフォリオ"
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <title>{title}</title>
+    <title>{pageTitle}</title>
     <meta name="description" content={excerpt} />
     <ClientRouter />
   </head>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,7 +170,7 @@ const qiitaArticles = await getCollection("qiita-articles");
         href="/talks"
         class="self-start text-cyan-600 underline hover:text-cyan-900"
       >
-        直近のすべての登壇
+        すべての登壇
       </a>
     </section>
     <section class="col-start-3 col-end-4 flex flex-col gap-y-4" id="blog">

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -6,12 +6,12 @@ import GlobalLayout from "../../layouts/GlobalLayout.astro";
 const allTalks = await getCollection("talks");
 ---
 
-<GlobalLayout>
+<GlobalLayout title="登壇">
   <div class="flex flex-col gap-16 px-3 pt-10 sm:px-5 md:px-7 md:pt-16">
     <article
       class="flex w-full max-w-[var(--container-3xl)] flex-col gap-y-6 self-center sm:gap-y-8"
     >
-      <h1 class="text-3xl font-bold sm:text-5xl md:text-7xl">登壇実績</h1>
+      <h1 class="text-3xl font-bold sm:text-5xl md:text-7xl">登壇</h1>
       {
         allTalks
           .sort((a, b) => new Date(b.id).getTime() - new Date(a.id).getTime())


### PR DESCRIPTION
## 概要
- 2022年の登壇履歴を7件追加
- 2025年のFigma Config Recapイベントを追加
- ページタイトルとh1ヘッディングを修正

Closes #318

Generated with [Claude Code](https://claude.ai/code)